### PR TITLE
chore: remove outdated vercel function config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,10 +7,5 @@
   "regions": ["iad1"],
   "env": {
     "NEXT_PUBLIC_API_URL": "https://fsw-iron-task-api.up.railway.app"
-  },
-  "functions": {
-    "web/app/api/auth/[...nextauth]/route.ts": {
-      "maxDuration": 10
-    }
   }
 }


### PR DESCRIPTION
## Summary
- remove reference to non-existent auth function in Vercel config

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6522c25b8832eb5a5a098708b9752